### PR TITLE
Remove SRI hash from Google fonts.

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 	<link href="css/skeleton.css" rel="stylesheet" type="text/css">
 	<link href="css/stylesheet.css" rel="stylesheet" type="text/css">
 	<link rel="stylesheet" href="https://code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css" integrity="sha384-4r9SMzlCiUSd92w9v1wROFY7DlBc5sDYaEBhcCJR7Pm2nuzIIGKVRtYWlf6w+GG4" crossorigin="anonymous">
-	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Serif%7CPlayfair+Display" integrity="sha384-qYy0Gjhpe50sVArb2zGmbIUqLKU4ptuVt0JAg1CRPhMpsiW/6mU1MROk2w15PQuP" crossorigin="anonymous">
+	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Serif%7CPlayfair+Display">
 </head>
 <body>
 	<div class="section landing">


### PR DESCRIPTION
Since Google fonts are dynamic we cannot use SRI hashes.