### PR TITLE
Include .well-known on Jekyll page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,2 @@
+include:
+- .well-known


### PR DESCRIPTION
By default Jekyll doesn't include dot files