### PR TITLE
Make placeholder for the generator RFC compliant

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@ active: 1
             <div class="field">
                 <label for="contact">Contact: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-04#section-3.4.2">(description)</a> *</label>
                 <div class="control">
-                    <input name="contact" id="contact" class="input" placeholder="security@example.com" required>
+                    <input name="contact" id="contact" class="input" placeholder="mailto:security@example.com" required>
                 </div>
             </div>
             <div class="field">


### PR DESCRIPTION
Based on the security.txt RFC specification ([section 3.4.2](https://tools.ietf.org/html/draft-foudil-securitytxt-04#section-3.4.2)), the `Contact:` directive "MUST" follow RFC3986.

> The value MUST follow the general syntax described in [RFC3986].
> This means that "mailto" and "tel" URI schemes MUST be used when
> specifying email addresses and telephone numbers.

Therefore,

```diff
- security@example.com
+ mailto:security@example.com
```

Upon Googling, I believe that this placeholder may be partially responsible for invalid security.txt files which specify emails without the `mailto:` scheme.

**This pull request has not been tested.**