### PR TITLE
Bump draft links to -05, and use the new directives

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -66,7 +66,7 @@
                         <h2 class="subtitle">
                             A proposed standard which allows websites to define security policies.
                         </h2>
-                        <a href="https://tools.ietf.org/html/draft-foudil-securitytxt-05">Read the latest Internet draft &#8594;</a>
+                        <a href="https://tools.ietf.org/html/draft-foudil-securitytxt">Read the latest Internet draft &#8594;</a>
                     </div>
                 </div>
                 <div class="hero-foot">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -66,7 +66,7 @@
                         <h2 class="subtitle">
                             A proposed standard which allows websites to define security policies.
                         </h2>
-                        <a href="https://tools.ietf.org/html/draft-foudil-securitytxt-04">Read the latest Internet draft &#8594;</a>
+                        <a href="https://tools.ietf.org/html/draft-foudil-securitytxt-05">Read the latest Internet draft &#8594;</a>
                     </div>
                 </div>
                 <div class="hero-foot">

--- a/index.html
+++ b/index.html
@@ -30,43 +30,43 @@ active: 1
         <br>
         <form id="genform">
             <div class="field">
-                <label for="contact">Contact: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-05#section-3.5.3">(description)</a> *</label>
+                <label for="contact">Contact: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.3">(description)</a> *</label>
                 <div class="control">
                     <input name="contact" id="contact" class="input" placeholder="mailto:security@example.com" required>
                 </div>
             </div>
             <div class="field">
-                <label for="encryption">Encryption: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-05#section-3.5.4">(description)</a></label>
+                <label for="encryption">Encryption: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.4">(description)</a></label>
                 <div class="control">
                     <input name="encryption" id="encryption" class="input" placeholder="https://example.com/pgp-key.txt">
                 </div>
             </div>
             <div class="field">
-                <label for="acknowledgments">Acknowledgments: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-05#section-3.5.1">(description)</a></label>
+                <label for="acknowledgments">Acknowledgments: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.1">(description)</a></label>
                 <div class="control">
                     <input name="acknowledgments" id="acknowledgments" class="input" placeholder="https://example.com/hall-of-fame.html">
                 </div>
             </div>
             <div class="field">
-                <label for="preferredLanguages">Preferred-Languages: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-05#section-3.5.7">(description)</a></label>
+                <label for="preferredLanguages">Preferred-Languages: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.7">(description)</a></label>
                 <div class="control">
                     <input name="preferredLanguages" id="preferredLanguages" class="input" placeholder="en, es, ru">
                 </div>
             </div>
             <div class="field">
-                <label for="canonical">Canonical: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-05#section-3.5.2">(description)</a></label>
+                <label for="canonical">Canonical: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.2">(description)</a></label>
                 <div class="control">
                     <input name="canonical" id="canonical" class="input" placeholder="https://example.com/.well-known/security.txt.sig">
                 </div>
             </div>
            <div class="field">
-                <label for="policy">Policy: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-05#section-3.5.6">(description)</a></label>
+                <label for="policy">Policy: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.6">(description)</a></label>
                 <div class="control">
                     <input name="policy" id="policy" class="input" placeholder="https://example.com/security-policy.html">
                 </div>
             </div>
             <div class="field">
-                <label for="hiring">Hiring: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-05#section-3.5.5">(description)</a></label>
+                <label for="hiring">Hiring: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.5">(description)</a></label>
                 <div class="control">
                     <input name="hiring" id="hiring" class="input" placeholder="https://example.com/jobs.html">
                 </div>

--- a/index.html
+++ b/index.html
@@ -30,43 +30,43 @@ active: 1
         <br>
         <form id="genform">
             <div class="field">
-                <label for="contact">Contact: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-05#section-3.4.2">(description)</a> *</label>
+                <label for="contact">Contact: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-05#section-3.5.3">(description)</a> *</label>
                 <div class="control">
                     <input name="contact" id="contact" class="input" placeholder="mailto:security@example.com" required>
                 </div>
             </div>
             <div class="field">
-                <label for="encryption">Encryption: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-05#section-3.4.3">(description)</a></label>
+                <label for="encryption">Encryption: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-05#section-3.5.4">(description)</a></label>
                 <div class="control">
                     <input name="encryption" id="encryption" class="input" placeholder="https://example.com/pgp-key.txt">
                 </div>
             </div>
             <div class="field">
-                <label for="acknowledgements">Acknowledgements: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-05#section-3.4.1">(description)</a></label>
+                <label for="acknowledgements">Acknowledgements: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-05#section-3.5.1">(description)</a></label>
                 <div class="control">
                     <input name="acknowledgements" id="acknowledgements" class="input" placeholder="https://example.com/acknowledgements.html">
                 </div>
             </div>
             <div class="field">
-                <label for="permission">Permission: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-05#section-3.4.5">(description)</a></label>
+                <label for="preferredLanguages">Preferred-Languages: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-05#section-3.5.7">(description)</a></label>
                 <div class="control">
-                    <input name="permission" id="permission" class="input" placeholder="none">
+                    <input name="preferredLanguages" id="preferredLanguages" class="input" placeholder="en, es, ru">
                 </div>
             </div>
             <div class="field">
-                <label for="policy">Policy: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-05#section-3.4.6">(description)</a></label>
+                <label for="canonical">Canonical: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-05#section-3.5.2">(description)</a></label>
+                <div class="control">
+                    <input name="canonical" id="canonical" class="input" placeholder="https://example.com/.well-known/security.txt.sig">
+                </div>
+            </div>
+           <div class="field">
+                <label for="policy">Policy: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-05#section-3.5.6">(description)</a></label>
                 <div class="control">
                     <input name="policy" id="policy" class="input" placeholder="https://example.com/security-policy.html">
                 </div>
             </div>
             <div class="field">
-                <label for="signature">Signature: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-05#section-3.4.7">(description)</a></label>
-                <div class="control">
-                    <input name="signature" id="signature" class="input" placeholder="https://example.com/.well-known/security.txt.sig">
-                </div>
-            </div>
-            <div class="field">
-                <label for="hiring">Hiring: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-05#section-3.4.4">(description)</a></label>
+                <label for="hiring">Hiring: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-05#section-3.5.5">(description)</a></label>
                 <div class="control">
                     <input name="hiring" id="hiring" class="input" placeholder="https://example.com/jobs.html">
                 </div>

--- a/index.html
+++ b/index.html
@@ -42,9 +42,9 @@ active: 1
                 </div>
             </div>
             <div class="field">
-                <label for="acknowledgements">Acknowledgements: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-05#section-3.5.1">(description)</a></label>
+                <label for="acknowledgments">Acknowledgments: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-05#section-3.5.1">(description)</a></label>
                 <div class="control">
-                    <input name="acknowledgements" id="acknowledgements" class="input" placeholder="https://example.com/acknowledgements.html">
+                    <input name="acknowledgments" id="acknowledgments" class="input" placeholder="https://example.com/hall-of-fame.html">
                 </div>
             </div>
             <div class="field">

--- a/index.html
+++ b/index.html
@@ -30,43 +30,43 @@ active: 1
         <br>
         <form id="genform">
             <div class="field">
-                <label for="contact">Contact: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-04#section-3.4.2">(description)</a> *</label>
+                <label for="contact">Contact: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-05#section-3.4.2">(description)</a> *</label>
                 <div class="control">
                     <input name="contact" id="contact" class="input" placeholder="mailto:security@example.com" required>
                 </div>
             </div>
             <div class="field">
-                <label for="encryption">Encryption: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-04#section-3.4.3">(description)</a></label>
+                <label for="encryption">Encryption: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-05#section-3.4.3">(description)</a></label>
                 <div class="control">
                     <input name="encryption" id="encryption" class="input" placeholder="https://example.com/pgp-key.txt">
                 </div>
             </div>
             <div class="field">
-                <label for="acknowledgements">Acknowledgements: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-04#section-3.4.1">(description)</a></label>
+                <label for="acknowledgements">Acknowledgements: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-05#section-3.4.1">(description)</a></label>
                 <div class="control">
                     <input name="acknowledgements" id="acknowledgements" class="input" placeholder="https://example.com/acknowledgements.html">
                 </div>
             </div>
             <div class="field">
-                <label for="permission">Permission: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-04#section-3.4.5">(description)</a></label>
+                <label for="permission">Permission: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-05#section-3.4.5">(description)</a></label>
                 <div class="control">
                     <input name="permission" id="permission" class="input" placeholder="none">
                 </div>
             </div>
             <div class="field">
-                <label for="policy">Policy: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-04#section-3.4.6">(description)</a></label>
+                <label for="policy">Policy: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-05#section-3.4.6">(description)</a></label>
                 <div class="control">
                     <input name="policy" id="policy" class="input" placeholder="https://example.com/security-policy.html">
                 </div>
             </div>
             <div class="field">
-                <label for="signature">Signature: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-04#section-3.4.7">(description)</a></label>
+                <label for="signature">Signature: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-05#section-3.4.7">(description)</a></label>
                 <div class="control">
                     <input name="signature" id="signature" class="input" placeholder="https://example.com/.well-known/security.txt.sig">
                 </div>
             </div>
             <div class="field">
-                <label for="hiring">Hiring: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-04#section-3.4.4">(description)</a></label>
+                <label for="hiring">Hiring: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-05#section-3.4.4">(description)</a></label>
                 <div class="control">
                     <input name="hiring" id="hiring" class="input" placeholder="https://example.com/jobs.html">
                 </div>

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@ active: 1
             <div class="field">
                 <label for="canonical">Canonical: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.2">(description)</a></label>
                 <div class="control">
-                    <input name="canonical" id="canonical" class="input" placeholder="https://example.com/.well-known/security.txt.sig">
+                    <input name="canonical" id="canonical" class="input" placeholder="https://example.com/.well-known/security.txt">
                 </div>
             </div>
            <div class="field">

--- a/js/genform.js
+++ b/js/genform.js
@@ -1,7 +1,7 @@
 genform.addEventListener("submit", function(event){
     event.preventDefault();
     generate('security.txt', [
-        this.contact, this.encryption, this.acknowledgements,
+        this.contact, this.encryption, this.acknowledgments,
         this.preferredLanguages, this.canonical, this.policy, this.hiring
     ]);
 });

--- a/js/genform.js
+++ b/js/genform.js
@@ -1,6 +1,6 @@
 genform.addEventListener("submit", function(event){
     event.preventDefault();
-    generate('security.txt', [this['contact'], this['encryption'], this['acknowledgements'], this['permission'], this['policy'], this['signature'], this['hiring']]);
+    generate('security.txt', [this.contact, this.encryption, this.acknowledgements, this.permission, this.policy, this.signature, this.hiring]);
 });
 
 function generate(filename, field_array){

--- a/js/genform.js
+++ b/js/genform.js
@@ -7,7 +7,7 @@ genform.addEventListener("submit", function(event){
 });
 
 function generate(filename, field_array){
-    text = "";
+    var text = "";
     
     // Converts camel case like 'abcDefGhi' into
     // the format 'Abc-Def-Ghi'
@@ -19,10 +19,9 @@ function generate(filename, field_array){
       }).join('-')
     }
 
-    field_array.forEach(function(e, i){
-        console.log(i)
+    field_array.forEach(function(e){
         if(e.value.length > 0){
-            name = e.name;
+            var name = e.name;
             text += camelToHyphen(name) + ": " + e.value + "\n";
         }
     });
@@ -31,7 +30,7 @@ function generate(filename, field_array){
 }
 
 function copy(text){
-    elem = document.getElementById("text-to-copy");
+    var elem = document.getElementById("text-to-copy");
     elem.value = text;
 
     if(document.queryCommandSupported("copy")){

--- a/js/genform.js
+++ b/js/genform.js
@@ -4,10 +4,9 @@ genform.addEventListener("submit", function(event){
 });
 
 function generate(filename, field_array){
-    list = field_array;
     text = "";
 
-    list.forEach(function(e){
+    field_array.forEach(function(e){
         if(e.value.length > 0){
             name = e.name;
             text += name[0].toUpperCase() + name.slice(1) + ": " + e.value + "\n";

--- a/js/genform.js
+++ b/js/genform.js
@@ -5,11 +5,21 @@ genform.addEventListener("submit", function(event){
 
 function generate(filename, field_array){
     text = "";
+    
+    // Converts camel case like 'abcDefGhi' into
+    // the format 'Abc-Def-Ghi'
+    function camelToHyphen(camelCaseWord) {
+      var components = camelCaseWord.split(/(?=[A-Z])/) // abcDef => [abc, Def]
+      
+      return components.map(function (component) {
+        return component[0].toUpperCase() + component.slice(1) // ABC => Abc
+      }).join('-')
+    }
 
     field_array.forEach(function(e){
         if(e.value.length > 0){
             name = e.name;
-            text += name[0].toUpperCase() + name.slice(1) + ": " + e.value + "\n";
+            text += camelToHyphen(name) + ": " + e.value + "\n";
         }
     });
 

--- a/js/genform.js
+++ b/js/genform.js
@@ -1,6 +1,9 @@
 genform.addEventListener("submit", function(event){
     event.preventDefault();
-    generate('security.txt', [this.contact, this.encryption, this.acknowledgements, this.permission, this.policy, this.signature, this.hiring]);
+    generate('security.txt', [
+        this.contact, this.encryption, this.acknowledgements,
+        this.preferredLanguages, this.canonical, this.policy, this.hiring
+    ]);
 });
 
 function generate(filename, field_array){
@@ -16,7 +19,8 @@ function generate(filename, field_array){
       }).join('-')
     }
 
-    field_array.forEach(function(e){
+    field_array.forEach(function(e, i){
+        console.log(i)
         if(e.value.length > 0){
             name = e.name;
             text += camelToHyphen(name) + ": " + e.value + "\n";


### PR DESCRIPTION
All the links were pointing to the -04 draft. However, the -05 draft has been [published
](https://tools.ietf.org/html/draft-foudil-securitytxt-05)

Hence, update all those links. I used a regular expression matching for "-04" to do this.

In addition, make the following changes:
- Change the form for generating security.txt files so that it lists the new version of the directives
- Use more succint notation in the JavaScript
- Expand the camelCase -> directive converter to be able to handle multiple words
- Use the `var` keyword to ensure variables stay in their scope only