### PR TITLE
Don't automatically save generated file to clipboard

### DIFF
--- a/css/stylesheet.css
+++ b/css/stylesheet.css
@@ -66,14 +66,6 @@ body {
     margin-top: 1em;
 }
 
-#text-to-copy.copy {
-    margin: 0;
-    height: 0px;
-    width: 0px;
-    overflow: hidden;
-    position: absolute;
-}
-
 /* Extra CSS for Notifications */
 
 #txt-notification h1 {

--- a/index.html
+++ b/index.html
@@ -80,7 +80,16 @@ active: 1
     <div class="container">
         <h1 class="title">Step 2</h1>
         <p>You are ready to go! Publish your security.txt file.</p>
-        <textarea id="text-to-copy" class="copy" readonly></textarea>
+        <div class="field">
+          <div class="control">
+            <textarea id="text-to-copy" class="textarea" readonly></textarea>
+          </div>
+        </div>
+        <div class="field">
+          <div class="control">
+            <button id="copy-button" class="button button-primary" disabled="true" onclick="copyTextarea()">Copy to clipboard</button>
+          </div>
+        </div>
     </div>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@ active: 1
 
 <section class="section">
     <div class="container">
-        <h1 class="title">Step 2</h1>
+        <h1 class="title" id="step-two">Step 2</h1>
         <p>You are ready to go! Publish your security.txt file.</p>
         <div class="field">
           <div class="control">

--- a/js/genform.js
+++ b/js/genform.js
@@ -16,11 +16,11 @@ function generate(filename, field_array){
     // Converts camel case like 'abcDefGhi' into
     // the format 'Abc-Def-Ghi'
     function camelToHyphen(camelCaseWord) {
-      var components = camelCaseWord.split(/(?=[A-Z])/) // abcDef => [abc, Def]
-      
-      return components.map(function (component) {
-        return component[0].toUpperCase() + component.slice(1) // ABC => Abc
-      }).join('-')
+        var components = camelCaseWord.split(/(?=[A-Z])/) // abcDef => [abc, Def]
+
+        return components.map(function (component) {
+          return component[0].toUpperCase() + component.slice(1) // ABC => Abc
+        }).join('-')
     }
 
     field_array.forEach(function(e){
@@ -33,7 +33,7 @@ function generate(filename, field_array){
     textareaElement.value = text;
 
     if (document.queryCommandSupported("copy")) {
-      document.getElementById("copy-button").removeAttribute("disabled")
+        document.getElementById("copy-button").removeAttribute("disabled")
     }
 }
 
@@ -49,9 +49,9 @@ function scrollToStepTwo() {
   var stepTwo = document.getElementById("step-two")
 
   if (stepTwo.scrollIntoView) {
-    stepTwo.scrollIntoView({behavior: "smooth"})
+      stepTwo.scrollIntoView({behavior: "smooth"})
   } else {
-    location.hash = "step-two"
+      location.hash = "step-two"
   }
 }
 

--- a/js/genform.js
+++ b/js/genform.js
@@ -6,6 +6,8 @@ genform.addEventListener("submit", function(event){
         this.contact, this.encryption, this.acknowledgments,
         this.preferredLanguages, this.canonical, this.policy, this.hiring
     ]);
+
+    scrollToStepTwo()
 });
 
 function generate(filename, field_array){
@@ -41,6 +43,10 @@ function copyTextarea(){
 
     window.getSelection().empty();
     showNotification();
+}
+
+function scrollToStepTwo() {
+  document.getElementById("step-two").scrollIntoView({behavior: "smooth"})
 }
 
 notification = document.getElementById("txt-notification");

--- a/js/genform.js
+++ b/js/genform.js
@@ -1,3 +1,5 @@
+textareaElement = document.getElementById("text-to-copy");
+
 genform.addEventListener("submit", function(event){
     event.preventDefault();
     generate('security.txt', [
@@ -26,22 +28,19 @@ function generate(filename, field_array){
         }
     });
 
-    copy(text);
+    textareaElement.value = text;
+
+    if (document.queryCommandSupported("copy")) {
+      document.getElementById("copy-button").removeAttribute("disabled")
+    }
 }
 
-function copy(text){
-    var elem = document.getElementById("text-to-copy");
-    elem.value = text;
+function copyTextarea(){
+    textareaElement.select();
+    document.execCommand("copy");
 
-    if(document.queryCommandSupported("copy")){
-        elem.select();
-        document.execCommand("copy");
-        window.getSelection().empty();
-        showNotification();
-    } else {
-        elem.classList.remove("copy");
-        elem.classList.add("textarea");
-    }
+    window.getSelection().empty();
+    showNotification();
 }
 
 notification = document.getElementById("txt-notification");

--- a/js/genform.js
+++ b/js/genform.js
@@ -46,7 +46,13 @@ function copyTextarea(){
 }
 
 function scrollToStepTwo() {
-  document.getElementById("step-two").scrollIntoView({behavior: "smooth"})
+  var stepTwo = document.getElementById("step-two")
+
+  if (stepTwo.scrollIntoView) {
+    stepTwo.scrollIntoView({behavior: "smooth"})
+  } else {
+    location.hash = "step-two"
+  }
 }
 
 notification = document.getElementById("txt-notification");


### PR DESCRIPTION
This pull request makes ~~two~~ _three_ changes:

- Don't copy security.txt files to the clipboard, instead output them to a visible read-only textbox with a button that allows copying to the clipboard
- Once the form is submitted, scroll that textbox into view
- Make all the tabs consistent (four, not two, since I think it was originally four - spaces)

I looked at the level of support for `scrollIntoView`. Most browsers support it when the first argument is a Boolean. However, I'm passing an object so that the scrolling is smooth. I think it is very likely (but am not certain) that these older browsers will still scroll the element into view, even if they don't scroll smoothly.

~~I haven't added anything to handle browsers which don't support `scrollIntoView`. Should I? (I'd be happy to do so)~~ https://github.com/securitytxt/securitytxt.org/pull/28/commits/8eb8d28579e0961285989773c0d20275738ce85f will use the hash component of URLs to scroll to the relevant location as a fallback.