### PR TITLE
Allow multiple directive values, use Liquid to avoid repetition in HTML

### DIFF
--- a/css/stylesheet.css
+++ b/css/stylesheet.css
@@ -56,9 +56,15 @@ body {
     margin-bottom: 20px;
 }
 
-#genform label {
-    display: block;
-    margin-bottom: 5px;
+#genform fieldset.box {
+  border: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+#genform fieldset.box > legend {
+  background-color: white;
+  padding: 0 7px;
 }
 
 #text-to-copy {

--- a/index.html
+++ b/index.html
@@ -29,48 +29,195 @@ active: 1
         <p>Create a text file called <code>security.txt</code> under the <code>.well-known</code> directory of your project.</p>
         <br>
         <form id="genform">
-            <div class="field">
-                <label for="contact">Contact: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.3">(description)</a> *</label>
-                <div class="control">
-                    <input name="contact" id="contact" class="input" placeholder="mailto:security@example.com" required>
+            <fieldset class="box" id="contact">
+                <legend class="label">
+                    Contact
+                    <span class="tag is-danger">Required</span>
+                </legend>
+                <p class="help">A link or e-mail address for people to contact you about security issues. Remember to include "https://" for URLs, and "mailto:" for e-mails. See
+                  <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.3">
+                      the full description of Contact
+                  </a>
+                </p>
+                <ul class="list-of-inputs">
+                    <li class="field">
+                        <div class="control">
+                            <input class="input" placeholder="mailto:security@example.com" required>
+                        </div>
+                    </li>
+                </ul>
+                <div class="field">
+                    <div class="control">
+                        <button type="button" class="button" onclick="addAlternative(this)">
+                            Add another alternative
+                        </button>
+                    </div>
                 </div>
-            </div>
-            <div class="field">
-                <label for="encryption">Encryption: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.4">(description)</a></label>
-                <div class="control">
-                    <input name="encryption" id="encryption" class="input" placeholder="https://example.com/pgp-key.txt">
+            </fieldset>
+            <fieldset class="box" id="encryption">
+                <legend class="label">
+                    Encryption
+                    <span class="tag is-success">Optional</span>
+                </legend>
+                <p class="help">
+                    A key which security researchers should use to securely talk to you. Remember to include "https://". See
+                    <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.4">
+                        the full description of Encryption
+                    </a>
+                </p>
+                <ul class="list-of-inputs">
+                    <li class="field">
+                        <div class="control">
+                            <input class="input" placeholder="https://example.com/pgp-key.txt">
+                        </div>
+                    </li>
+                </ul>
+                <div class="field">
+                    <div class="control">
+                        <button type="button" class="button" onclick="addAlternative(this)">
+                            Add another alternative
+                        </button>
+                    </div>
                 </div>
-            </div>
-            <div class="field">
-                <label for="acknowledgments">Acknowledgments: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.1">(description)</a></label>
-                <div class="control">
-                    <input name="acknowledgments" id="acknowledgments" class="input" placeholder="https://example.com/hall-of-fame.html">
+            </fieldset>
+            <fieldset class="box" id="acknowledgments">
+                <legend class="label">
+                    Acknowledgments
+                    <span class="tag is-success">Optional</span>
+                </legend>
+                <p class="help">
+                    A link to a web page where you say thank you to security researchers who have helped you. Remember
+                    to include "https://". See
+                    <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.1">
+                        the full description of Acknowledgments
+                    </a>
+                </p>
+                <ul class="list-of-inputs">
+                    <li class="field">
+                        <div class="control">
+                            <input class="input" placeholder="https://example.com/hall-of-fame.html">
+                        </div>
+                    </li>
+                </ul>
+                <div class="field">
+                    <div class="control">
+                        <button type="button" class="button" onclick="addAlternative(this)">
+                            Add another alternative
+                        </button>
+                    </div>
                 </div>
-            </div>
-            <div class="field">
-                <label for="preferredLanguages">Preferred-Languages: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.7">(description)</a></label>
-                <div class="control">
-                    <input name="preferredLanguages" id="preferredLanguages" class="input" placeholder="en, es, ru">
+            </fieldset>
+            <fieldset class="box" id="preferredLanguages">
+                <legend class="label">
+                    Preferred-Languages
+                    <p class="tag is-success">Optional</p>
+                    <p class="tag is-info">Only 1 allowed</p>
+                </legend>
+                <p class="help">
+                    A comma-separated list of language codes that your security team speaks. <strong>You may include
+                    more than one language</strong>. See
+                    <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.7">
+                        the full description of Preferred-Languages
+                    </a>
+                </p>
+                <ul class="list-of-inputs">
+                    <li class="field">
+                        <div class="control">
+                            <input class="input" placeholder="en, es, ru">
+                        </div>
+                    </li>
+                </ul>
+                <div class="field">
+                    <div class="control">
+                        <button type="button" class="button" onclick="addAlternative(this)" disabled>
+                            Add another alternative
+                        </button>
+                    </div>
                 </div>
-            </div>
-            <div class="field">
-                <label for="canonical">Canonical: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.2">(description)</a></label>
-                <div class="control">
-                    <input name="canonical" id="canonical" class="input" placeholder="https://example.com/.well-known/security.txt">
+            </fieldset>
+            <fieldset class="box" id="canonical">
+                <legend class="label">
+                    Canonical
+                    <p class="tag is-success">Optional</p>
+                    <p class="tag is-info">Only 1 allowed</p>
+                </legend>
+                <p class="help">
+                    The most common URL for accessing your security.txt file. It is important to include this if you
+                    are digitally signing the security.txt file, so that researchers can know for sure that you didn't
+                    just steal someone else's file with the same content. See
+                    <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.2">
+                        the full description of Canonical
+                    </a>
+                </p>
+                <ul class="list-of-inputs">
+                    <li class="field">
+                        <div class="control">
+                            <input class="input" placeholder="https://example.com/.well-known/security.txt">
+                        </div>
+                    </li>
+                </ul>
+                <div class="field">
+                    <div class="control">
+                        <button type="button" class="button" onclick="addAlternative(this)" disabled>
+                            Add another alternative
+                        </button>
+                    </div>
                 </div>
-            </div>
-           <div class="field">
-                <label for="policy">Policy: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.6">(description)</a></label>
-                <div class="control">
-                    <input name="policy" id="policy" class="input" placeholder="https://example.com/security-policy.html">
+            </fieldset>
+            <fieldset class="box" id="policy">
+                <legend class="label">
+                    Policy
+                    <p class="tag is-success">Optional</p>
+                </legend>
+                <p class="help">
+                    A link to a policy detailing what security researchers should do when searching for or reporting
+                    security issues. Remember to include "https://". See
+                    <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.6">
+                        the full description of Policy
+                    </a>
+                </p>
+                <ul class="list-of-inputs">
+                    <li class="field">
+                        <div class="control">
+                            <input class="input" placeholder="https://example.com/security-policy.html">
+                        </div>
+                    </li>
+                </ul>
+                <div class="field">
+                    <div class="control">
+                        <button type="button" class="button" onclick="addAlternative(this)">
+                            Add another alternative
+                        </button>
+                    </div>
                 </div>
-            </div>
-            <div class="field">
-                <label for="hiring">Hiring: <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.5">(description)</a></label>
-                <div class="control">
-                    <input name="hiring" id="hiring" class="input" placeholder="https://example.com/jobs.html">
+            </fieldset>
+            <fieldset class="box" id="hiring">
+                <legend class="label">
+                    Hiring
+                    <p class="tag is-success">Optional</p>
+                </legend>
+                <p class="help">
+                    A link to any security-related job openings in your organisation. Remember to include "https://".
+                    See
+                    <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.5">
+                        the full description of Hiring
+                    </a>
+                </p>
+                <ul class="list-of-inputs">
+                    <li class="field">
+                        <div class="control">
+                            <input class="input" placeholder="https://example.com/jobs.html">
+                        </div>
+                    </li>
+                </ul>
+                <div class="field">
+                    <div class="control">
+                        <button type="button" class="button" onclick="addAlternative(this)">
+                            Add another alternative
+                        </button>
+                    </div>
                 </div>
-            </div>
+            </fieldset>
             <input class="button button-primary" type="submit" value="Generate security.txt file">
         </form>
     </div>

--- a/index.html
+++ b/index.html
@@ -7,37 +7,43 @@ directive_tags:
     Optional: is-success
     Only 1 allowed: is-info
 directives:
-    Contact:
+    -
+        name: Contact
+        id: contact
         tags: ['Required']
         help: >
             A link or e-mail address for people to contact you about security issues. Remember to include "https://"
             for URLs, and "mailto:" for e-mails.
         placeholder: mailto:security@example.com
         spec: 3
-        id: contact
-    Encryption:
+    -
+        name: Encryption
+        id: encryption
         tags: ['Optional']
         help: A link to a key which security researchers should use to securely talk to you. Remember to include "https://".
         placeholder: https://example.com/pgp-key.txt
         spec: 4
-        id: encryption
-    Acknowledgments:
+    -
+        name: Acknowledgments
+        id: acknowledgments
         tags: ['Optional']
         help: >
             A link to a web page where you say thank you to security researchers who have helped you. Remember
             to include "https://".
         placeholder: https://example.com/hall-of-fame.html
         spec: 1
-        id: acknowledgments
-    Preferred-Languages:
+    -
+        name: Preferred-Languages
+        id: preferredLanguages
         tags: ['Optional', 'Only 1 allowed']
         help: >
             A comma-separated list of language codes that your security team speaks. <strong>You may include more
             than one language</strong>.
         placeholder: en, es, ru
         spec: 7
-        id: preferredLanguages
-    Canonical:
+    -
+        name: Canonical
+        id: canonical
         tags: ['Optional', 'Only 1 allowed']
         help: >
             The most common URL for accessing your security.txt file. It is important to include this if you are
@@ -45,21 +51,22 @@ directives:
             someone else's file with the same content.
         placeholder: https://example.com/.well-known/security.txt
         spec: 2
-        id: canonical
-    Policy:
+    -
+        name: Policy
+        id: policy
         tags: ['Optional']
         help: >
             A link to a policy detailing what security researchers should do when searching for or reporting security
             issues. Remember to include "https://".
         placeholder: https://example.com/security-policy.html
         spec: 6
-        id: policy
-    Hiring:
+    -
+        name: Hiring
+        id: hiring
         tags: ['Optional']
         help: A link to any security-related job openings in your organisation. Remember to include "https://".
         placeholder: https://example.com/jobs.html
         spec: 5
-        id: hiring
 ---
 
 <div id="txt-notification">
@@ -89,27 +96,25 @@ directives:
         <br>
         <form id="genform">
             {% for directive in page.directives %}
-                {% assign directive_name = directive[0] %}
-                {% assign directive_info = directive[1] %}
-                <fieldset class="box" id="{{directive_info.id}}">
+                <fieldset class="box" id="{{directive.id}}">
                     <legend class="label">
-                        {{ directive_name }}
-                        {% for tag in directive_info.tags %}
+                        {{ directive.name }}
+                        {% for tag in directive.tags %}
                             <span class="tag {{ page.directive_tags[tag] }}">{{ tag }}</span>
                         {% endfor %}
                     </legend>
                     <p class="help">
-                        {{ directive_info.help }} See 
+                        {{ directive.help }} See 
                         <a target="_blank" rel="noopener" 
-                           href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.{{directive_info.spec}}">
-                            the full description of {{ directive_name }}
+                           href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.{{directive.spec}}">
+                            the full description of {{ directive.name }}
                         </a>
                     </p>
                     <ul class="list-of-inputs">
                         <li class="field">
                             <div class="control">
-                                <input class="input" placeholder="{{ directive_info.placeholder }}"
-                                       {% if directive_info.tags contains 'Required' %} required {% endif %}
+                                <input class="input" placeholder="{{ directive.placeholder }}"
+                                       {% if directive.tags contains 'Required' %} required {% endif %}
                                 >
                             </div>
                         </li>
@@ -117,7 +122,7 @@ directives:
                     <div class="field">
                         <div class="control">
                             <button type="button" class="button" onclick="addAlternative(this)"
-                                {% if directive_info.tags contains 'Only 1 allowed' %} disabled {% endif %}
+                                {% if directive.tags contains 'Only 1 allowed' %} disabled {% endif %}
                             >
                                 Add another alternative
                             </button>

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 layout: default
 index: true
 active: 1
-tags:
+directive_tags:
     Required: is-danger
     Optional: is-success
     Only 1 allowed: is-info
@@ -95,7 +95,7 @@ directives:
                     <legend class="label">
                         {{ directive_name }}
                         {% for tag in directive_info.tags %}
-                            <span class="tag {{ page.tags[tag] }}">{{ tag }}</span>
+                            <span class="tag {{ page.directive_tags[tag] }}">{{ tag }}</span>
                         {% endfor %}
                     </legend>
                     <p class="help">

--- a/index.html
+++ b/index.html
@@ -2,7 +2,66 @@
 layout: default
 index: true
 active: 1
+tags:
+    Required: is-danger
+    Optional: is-success
+    Only 1 allowed: is-info
+directives:
+    Contact:
+        tags: ['Required']
+        help: >
+            A link or e-mail address for people to contact you about security issues. Remember to include "https://"
+            for URLs, and "mailto:" for e-mails.
+        placeholder: mailto:security@example.com
+        spec: 3
+        id: contact
+    Encryption:
+        tags: ['Optional']
+        help: A link to a key which security researchers should use to securely talk to you. Remember to include "https://".
+        placeholder: https://example.com/pgp-key.txt
+        spec: 4
+        id: encryption
+    Acknowledgments:
+        tags: ['Optional']
+        help: >
+            A link to a web page where you say thank you to security researchers who have helped you. Remember
+            to include "https://".
+        placeholder: https://example.com/hall-of-fame.html
+        spec: 1
+        id: acknowledgments
+    Preferred-Languages:
+        tags: ['Optional', 'Only 1 allowed']
+        help: >
+            A comma-separated list of language codes that your security team speaks. <strong>You may include more
+            than one language</strong>.
+        placeholder: en, es, ru
+        spec: 7
+        id: preferredLanguages
+    Canonical:
+        tags: ['Optional', 'Only 1 allowed']
+        help: >
+            The most common URL for accessing your security.txt file. It is important to include this if you are
+            digitally signing the security.txt file, so that researchers can know for sure that you didn't just steal
+            someone else's file with the same content.
+        placeholder: https://example.com/.well-known/security.txt
+        spec: 2
+        id: canonical
+    Policy:
+        tags: ['Optional']
+        help: >
+            A link to a policy detailing what security researchers should do when searching for or reporting security
+            issues. Remember to include "https://".
+        placeholder: https://example.com/security-policy.html
+        spec: 6
+        id: policy
+    Hiring:
+        tags: ['Optional']
+        help: A link to any security-related job openings in your organisation. Remember to include "https://".
+        placeholder: https://example.com/jobs.html
+        spec: 5
+        id: hiring
 ---
+
 <div id="txt-notification">
     <div class="notification is-success is-pulled">
         <button onclick="removeNotification()" class="delete"></button>
@@ -29,196 +88,44 @@ active: 1
         <p>Create a text file called <code>security.txt</code> under the <code>.well-known</code> directory of your project.</p>
         <br>
         <form id="genform">
-            <fieldset class="box" id="contact">
-                <legend class="label">
-                    Contact
-                    <span class="tag is-danger">Required</span>
-                </legend>
-                <p class="help">A link or e-mail address for people to contact you about security issues. Remember to include "https://" for URLs, and "mailto:" for e-mails. See
-                  <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.3">
-                      the full description of Contact
-                  </a>
-                </p>
-                <ul class="list-of-inputs">
-                    <li class="field">
+            {% for directive in page.directives %}
+                {% assign directive_name = directive[0] %}
+                {% assign directive_info = directive[1] %}
+                <fieldset class="box" id="{{directive_info.id}}">
+                    <legend class="label">
+                        {{ directive_name }}
+                        {% for tag in directive_info.tags %}
+                            <span class="tag {{ page.tags[tag] }}">{{ tag }}</span>
+                        {% endfor %}
+                    </legend>
+                    <p class="help">
+                        {{ directive_info.help }} See 
+                        <a target="_blank" rel="noopener" 
+                           href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.{{directive_info.spec}}">
+                            the full description of {{ directive_name }}
+                        </a>
+                    </p>
+                    <ul class="list-of-inputs">
+                        <li class="field">
+                            <div class="control">
+                                <input class="input" placeholder="{{ directive_info.placeholder }}"
+                                       {% if directive_info.tags contains 'Required' %} required {% endif %}
+                                >
+                            </div>
+                        </li>
+                    </ul>
+                    <div class="field">
                         <div class="control">
-                            <input class="input" placeholder="mailto:security@example.com" required>
+                            <button type="button" class="button" onclick="addAlternative(this)"
+                                {% if directive_info.tags contains 'Only 1 allowed' %} disabled {% endif %}
+                            >
+                                Add another alternative
+                            </button>
                         </div>
-                    </li>
-                </ul>
-                <div class="field">
-                    <div class="control">
-                        <button type="button" class="button" onclick="addAlternative(this)">
-                            Add another alternative
-                        </button>
                     </div>
-                </div>
-            </fieldset>
-            <fieldset class="box" id="encryption">
-                <legend class="label">
-                    Encryption
-                    <span class="tag is-success">Optional</span>
-                </legend>
-                <p class="help">
-                    A link to a key which security researchers should use to securely talk to you. Remember to include "https://". See
-                    <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.4">
-                        the full description of Encryption
-                    </a>
-                </p>
-                <ul class="list-of-inputs">
-                    <li class="field">
-                        <div class="control">
-                            <input class="input" placeholder="https://example.com/pgp-key.txt">
-                        </div>
-                    </li>
-                </ul>
-                <div class="field">
-                    <div class="control">
-                        <button type="button" class="button" onclick="addAlternative(this)">
-                            Add another alternative
-                        </button>
-                    </div>
-                </div>
-            </fieldset>
-            <fieldset class="box" id="acknowledgments">
-                <legend class="label">
-                    Acknowledgments
-                    <span class="tag is-success">Optional</span>
-                </legend>
-                <p class="help">
-                    A link to a web page where you say thank you to security researchers who have helped you. Remember
-                    to include "https://". See
-                    <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.1">
-                        the full description of Acknowledgments
-                    </a>
-                </p>
-                <ul class="list-of-inputs">
-                    <li class="field">
-                        <div class="control">
-                            <input class="input" placeholder="https://example.com/hall-of-fame.html">
-                        </div>
-                    </li>
-                </ul>
-                <div class="field">
-                    <div class="control">
-                        <button type="button" class="button" onclick="addAlternative(this)">
-                            Add another alternative
-                        </button>
-                    </div>
-                </div>
-            </fieldset>
-            <fieldset class="box" id="preferredLanguages">
-                <legend class="label">
-                    Preferred-Languages
-                    <p class="tag is-success">Optional</p>
-                    <p class="tag is-info">Only 1 allowed</p>
-                </legend>
-                <p class="help">
-                    A comma-separated list of language codes that your security team speaks. <strong>You may include
-                    more than one language</strong>. See
-                    <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.7">
-                        the full description of Preferred-Languages
-                    </a>
-                </p>
-                <ul class="list-of-inputs">
-                    <li class="field">
-                        <div class="control">
-                            <input class="input" placeholder="en, es, ru">
-                        </div>
-                    </li>
-                </ul>
-                <div class="field">
-                    <div class="control">
-                        <button type="button" class="button" onclick="addAlternative(this)" disabled>
-                            Add another alternative
-                        </button>
-                    </div>
-                </div>
-            </fieldset>
-            <fieldset class="box" id="canonical">
-                <legend class="label">
-                    Canonical
-                    <p class="tag is-success">Optional</p>
-                    <p class="tag is-info">Only 1 allowed</p>
-                </legend>
-                <p class="help">
-                    The most common URL for accessing your security.txt file. It is important to include this if you
-                    are digitally signing the security.txt file, so that researchers can know for sure that you didn't
-                    just steal someone else's file with the same content. See
-                    <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.2">
-                        the full description of Canonical
-                    </a>
-                </p>
-                <ul class="list-of-inputs">
-                    <li class="field">
-                        <div class="control">
-                            <input class="input" placeholder="https://example.com/.well-known/security.txt">
-                        </div>
-                    </li>
-                </ul>
-                <div class="field">
-                    <div class="control">
-                        <button type="button" class="button" onclick="addAlternative(this)" disabled>
-                            Add another alternative
-                        </button>
-                    </div>
-                </div>
-            </fieldset>
-            <fieldset class="box" id="policy">
-                <legend class="label">
-                    Policy
-                    <p class="tag is-success">Optional</p>
-                </legend>
-                <p class="help">
-                    A link to a policy detailing what security researchers should do when searching for or reporting
-                    security issues. Remember to include "https://". See
-                    <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.6">
-                        the full description of Policy
-                    </a>
-                </p>
-                <ul class="list-of-inputs">
-                    <li class="field">
-                        <div class="control">
-                            <input class="input" placeholder="https://example.com/security-policy.html">
-                        </div>
-                    </li>
-                </ul>
-                <div class="field">
-                    <div class="control">
-                        <button type="button" class="button" onclick="addAlternative(this)">
-                            Add another alternative
-                        </button>
-                    </div>
-                </div>
-            </fieldset>
-            <fieldset class="box" id="hiring">
-                <legend class="label">
-                    Hiring
-                    <p class="tag is-success">Optional</p>
-                </legend>
-                <p class="help">
-                    A link to any security-related job openings in your organisation. Remember to include "https://".
-                    See
-                    <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.5">
-                        the full description of Hiring
-                    </a>
-                </p>
-                <ul class="list-of-inputs">
-                    <li class="field">
-                        <div class="control">
-                            <input class="input" placeholder="https://example.com/jobs.html">
-                        </div>
-                    </li>
-                </ul>
-                <div class="field">
-                    <div class="control">
-                        <button type="button" class="button" onclick="addAlternative(this)">
-                            Add another alternative
-                        </button>
-                    </div>
-                </div>
-            </fieldset>
-            <input class="button is-success" type="submit" value="Generate security.txt file">
+                </fieldset>
+            {% endfor %}
+           <input class="button is-success" type="submit" value="Generate security.txt file">
         </form>
     </div>
 </section>

--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@ active: 1
                     <span class="tag is-success">Optional</span>
                 </legend>
                 <p class="help">
-                    A key which security researchers should use to securely talk to you. Remember to include "https://". See
+                    A link to a key which security researchers should use to securely talk to you. Remember to include "https://". See
                     <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt#section-3.5.4">
                         the full description of Encryption
                     </a>

--- a/index.html
+++ b/index.html
@@ -218,7 +218,7 @@ active: 1
                     </div>
                 </div>
             </fieldset>
-            <input class="button button-primary" type="submit" value="Generate security.txt file">
+            <input class="button is-success" type="submit" value="Generate security.txt file">
         </form>
     </div>
 </section>
@@ -226,7 +226,7 @@ active: 1
 <section class="section">
     <div class="container">
         <h1 class="title">Step 2</h1>
-        <p>You are ready to go! Publish your security.txt file.</p>
+        <p>You are ready to go! Publish your security.txt file. If you want to give security researchers confidence that your security.txt file is authentic, and not planted by an attacker, consider <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt-05#section-3.4">digitally signing</a> the file with an OpenPGP cleartext signature.</p>
         <textarea id="text-to-copy" class="copy" readonly></textarea>
     </div>
 </section>

--- a/js/genform.js
+++ b/js/genform.js
@@ -1,8 +1,7 @@
 genform.addEventListener("submit", function(event){
     event.preventDefault();
     generate('security.txt', [
-        this.contact, this.encryption, this.acknowledgments,
-        this.preferredLanguages, this.canonical, this.policy, this.hiring
+        "contact", "encryption", "acknowledgments", "preferredLanguages", "canonical", "policy", "hiring"
     ]);
 });
 
@@ -20,13 +19,52 @@ function generate(filename, field_array){
     }
 
     field_array.forEach(function(e){
-        if(e.value.length > 0){
-            var name = e.name;
-            text += camelToHyphen(name) + ": " + e.value + "\n";
-        }
+        console.log(e)
+        var inputs = document.getElementById(e).querySelector(".list-of-inputs")
+
+        inputs.querySelectorAll("input").forEach(function(child) {
+            if(child.value.length > 0){
+                text += camelToHyphen(e) + ": " + child.value + "\n";
+            }
+        });
     });
 
     copy(text);
+}
+
+function addAlternative(button) {
+    var list = button.parentElement.parentElement.parentElement.querySelector(".list-of-inputs")
+    
+    var newInput = document.createElement("INPUT")
+    newInput.setAttribute("placeholder", "Another possible alternative")
+    newInput.setAttribute("class", "input")
+
+    var newInputControl = document.createElement("DIV")
+    newInputControl.setAttribute("class", "control is-expanded")
+    newInputControl.appendChild(newInput)
+
+    var removeButton = document.createElement("BUTTON")
+    removeButton.setAttribute("type", "button")
+    removeButton.setAttribute("class", "button is-danger")
+    removeButton.textContent = "Remove"
+    
+    var removeButtonControl = document.createElement("DIV")
+    removeButtonControl.setAttribute("class", "control")
+    removeButtonControl.appendChild(removeButton)
+
+    var overallField = document.createElement("LI")
+    overallField.setAttribute("class", "field is-grouped")
+    overallField.appendChild(newInputControl)
+    overallField.appendChild(removeButtonControl)
+
+    removeButton.addEventListener("click", function() {
+        // not using Element.remove() to maintain support
+        // with Internet Explorer
+        overallField.parentNode.removeChild(overallField)
+    })
+
+    list.appendChild(overallField)
+    newInput.focus()
 }
 
 function copy(text){


### PR DESCRIPTION
Resolves #27 
Resolves #30 

This pull request makes the following changes:
- Use the Liquid templating language to avoid repetition of HTML code
- Add some help text so that users don't have to look at the spec to figure out what to put.
- Move the links to the spec sections into that help text
- Add "tags" next to the headings so that it is clear whether the directive is optional, required, and whether it can have more than one alternative
- Add a button called "Add another alternative", which, when clicked, constructs an input with a "Remove" button and gives that new input focus. This pull requests adds the JavaScript to handle multiple inputs and to construct a security.txt file from them.
- Disable (i.e. grey out) those buttons when only one alternative is allowed. (I decided that this applies to "Preferred-Languages", though ideally we'd abstract away that fact and still let the user add alternatives, and keep one language code per alternative (we'd then need to string these together ourselves). The help text for that directive makes it clear that multiple languages are allowed though.)
- Add a note in the "Step 2" section about digitally signing files
- Make the "Generate" button green to distinguish it from all the other buttons.
- Use `<legend>` instead of `<label>` now that we can have multiple inputs per label.

Pictures!!!

![The redesigned view of the Contact and Encryption directives](https://user-images.githubusercontent.com/18113170/53699104-ab723980-3ddc-11e9-8948-9cfcc0854555.png)

![The "Preferred Languages" and "Canonical" fields are both marked as "Only 1 allowed", and the former has a bold note explaining that multiple language codes are indeed allowed nonetheless](https://user-images.githubusercontent.com/18113170/53699120-d6f52400-3ddc-11e9-8d51-17d2dae407b3.png)

![The "Generate security.txt file is now light green, the same colour as the "Optional" tags](https://user-images.githubusercontent.com/18113170/53699154-41a65f80-3ddd-11e9-8a0c-310e4ec07966.png)

!["Step Two" now describes digitally signing files](https://user-images.githubusercontent.com/18113170/53699173-64d10f00-3ddd-11e9-969e-eac5966111a6.png)


Note that I have fixed the help text for Encryption since taking that screenshot. It now says "a link to" a key. 