### PR TITLE
Set vertical alignment of scrolled element

### DIFF
--- a/js/genform.js
+++ b/js/genform.js
@@ -87,7 +87,7 @@ function scrollToStepTwo() {
   var stepTwo = document.getElementById("step-two")
 
   if (stepTwo.scrollIntoView) {
-      stepTwo.scrollIntoView({behavior: "smooth"})
+      stepTwo.scrollIntoView({behavior: "smooth", block: "start"})
   } else {
       location.hash = "step-two"
   }


### PR DESCRIPTION
It is clear that browser defaults are not standardised for the vertical alignment.

This pull request explicitly sets the vertical alignment of the scrolled element, to maintain compatibility with Chrome.