### PR TITLE
Append Unix timestamp for cache invalidation

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -30,7 +30,7 @@
     <!-- Stylesheets -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.6.2/css/bulma.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto">
-    <link rel="stylesheet" href="{{ "/css/stylesheet.css" | relative_url }}">
+    <link rel="stylesheet" href="{{ "/css/stylesheet.css" | relative_url }}?v={{ site.time | date: "%s" }}">
 </head>
 <body {% if page.index != null %}class="index"{% endif %}>
     <div id="wrapper">

--- a/index.html
+++ b/index.html
@@ -173,4 +173,4 @@ directives:
     </div>
 </section>
 
-<script src="{{ "/js/genform.js" | relative_url }}"></script>
+<script src="{{ "/js/genform.js" | relative_url}}?v={{ site.time | date: "%s" }}"></script>


### PR DESCRIPTION
Resolves #32 

Append the number of seconds since 1970-01-01 to the URLs of internal resources in order to force a re-request of JavaScript, CSS and HTML when the site is re-built. This is so that the HTML, CSS, and JS are always synchronised.

This is important because sometimes JavaScript will encounter a fatal error if the HTML is not what is expected.

Only internal links (I only found two) are targetted, because they aren't expected to change at site build time, but instead at a more controlled moment. We can always append the timestamp in future and this will invalidate any current caches.