### PR TITLE
Add a hyperlink for a ref to an RFC

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@ directives:
         <h5>Is security.txt an <a href="https://en.wikipedia.org/wiki/Request_for_Comments">RFC</a>?</h5>
         <p>security.txt is currently an Internet draft that has been submitted for RFC review. This means that security.txt is still in the early stages of development. We welcome contributions from the public: <a href="https://github.com/securitytxt/security-txt">https://github.com/securitytxt/security-txt</a></p>
         <h5>Where should I put the security.txt file?</h5>
-        <p>The security.txt file should be placed under the <code>/.well-known/</code> path (<code>/.well-known/security.txt</code>) [RFC5785].</p>
+        <p>The security.txt file should be placed under the <code>/.well-known/</code> path (<code>/.well-known/security.txt</code>) [<a href="https://tools.ietf.org/html/rfc5785">RFC5785</a>].</p>
         <h5>Will adding an email address expose me to spam bots?</h5>
         <p>The email value is an optional field. If you are worried about spam, you can set a URI as the value and link to your security policy.</p>
     </div>


### PR DESCRIPTION
Adds a hyperlink for the reference to RFC5785 so as to save the user time when they are looking things up.