### PR TITLE
Make minor improvements to the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # securitytxt.org
 
-![image](https://user-images.githubusercontent.com/18099289/42649227-5bbbb1f4-8609-11e8-988c-ad7b41b8873e.png)
+![The website of the security.txt project, a proposed standard which allows websites to define security policies](https://user-images.githubusercontent.com/18099289/42649227-5bbbb1f4-8609-11e8-988c-ad7b41b8873e.png)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The security.txt project accepts donations via [Liberapay](https://liberapay.com
 
 <a href="https://liberapay.com/security.txt/donate"><img alt="Donate using Liberapay" src="https://liberapay.com/assets/widgets/donate.svg"></a>
 
-<a href="https://opencollective.com/securitytxt/donate" target="_blank">
+<a href="https://opencollective.com/securitytxt/donate" target="_blank" rel="noopener">
   <img src="https://opencollective.com/securitytxt/donate/button@2x.png?color=blue" width=300 />
 </a>
 


### PR DESCRIPTION
This pull request makes two changes:
- https://github.com/securitytxt/securitytxt.org/commit/a4b201ef07de9b857fd81d43b7348d3741879daf Give the top image some alternative text. The image adds value to the document by explaining that the repository concerns a website that details a way for websites to define a security policy. This information replaces the less descriptive previous `alt` attribute of "image"
- https://github.com/securitytxt/securitytxt.org/commit/5cf62596128ed89b045b1c88fddb4f62083ab143 Resolves a potential security-related issue. In particular, it resolves the security issue of reverse tabnabbing. In this particular case, the issue is **not** exploitable since GitHub ignores the request that the link open in a new tab; and markdown files do not usually open locally in the browser. To comply with best practices, we fix it anyway.