### PR TITLE
Add security.txt browser extension

### DIFF
--- a/projects.html
+++ b/projects.html
@@ -18,5 +18,6 @@ active: 2
         <p><a href="https://www.drupal.org/project/securitytxt">Security.txt for Drupal</a> by <a href="https://www.drupal.org/u/danieljrmay">Daniel May</a>.</p>
         <p><a href="https://github.com/quietray/securitytxt-project">Templates for securitytxt implementation</a> by <a href="https://twitter.com/techrae">Favian Eric Raygoza</a>.</p>
         <p><a href="https://github.com/CHG-MERIDIAN/CHG.Extensions.Security.Txt">A middleware to represent the "security.txt" for ASP.NET Core applications.</a> by <a href="https://github.com/CHG-MERIDIAN">CHG-MERIDIAN AG</a>.</p>
+        <p><a href="https://github.com/HarmlessSystems/security.txt">A browser extension for discovering security.txt files</a> by <a href="https://harmless.systems/">Harmless Systems</a></p>
     </div>
 </section>


### PR DESCRIPTION
Hello, we've created an [open source browser extension](https://github.com/HarmlessSystems/security.txt) for discovering security.txt (and optionally humans.txt files) as you browse the web and would like to add it to your project list if possible.

We have a short blog post with more info here: https://www.harmless.systems/blog/2020-01-18-security-txt-browser-extension.html

Thanks