### PR TITLE
Allow Canonical to appear more than once

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,9 +44,9 @@ directives:
     -
         name: Canonical
         id: canonical
-        tags: ['Optional', 'Only 1 allowed']
+        tags: ['Optional']
         help: >
-            The most common URL for accessing your security.txt file. It is important to include this if you are
+            The URLs for accessing your security.txt file. It is important to include this if you are
             digitally signing the security.txt file, so that researchers can know for sure that you didn't just steal
             someone else's file with the same content.
         placeholder: https://example.com/.well-known/security.txt


### PR DESCRIPTION
We should probably wait for the changes in securitytxt/security-txt#183 to be published before merging this.

The `Canonical` field can now appear more than once in a security.txt file.