### PR TITLE
Add 'Expires' to genform, using bulma-calendar

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -30,6 +30,10 @@
     <meta name="og:type" content="website">
     <!-- Stylesheets -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.6.2/css/bulma.css">
+
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma-calendar@6.0.0/dist/css/bulma-calendar.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/bulma-calendar@6.0.0/dist/js/bulma-calendar.min.js"></script>    
+
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto">
     <link rel="stylesheet" href="{{ "/css/stylesheet.css" | relative_url }}?v={{ site.time | date: "%s" }}">
     <script type='application/ld+json'> 
@@ -39,7 +43,7 @@
       "name": "security.txt",
       "url": "https://securitytxt.org/"
     }
-     </script>
+    </script>
 </head>
 <body {% if page.index != null %}class="index"{% endif %}>
     <div id="wrapper">

--- a/index.html
+++ b/index.html
@@ -17,6 +17,15 @@ directives:
         placeholder: mailto:security@example.com
         spec: 3
     -
+        name: Expires
+        id: expires
+        tags: ['Required', 'Only 1 allowed']
+        help: >
+            The date and time when the content of the security.txt file should be considered stale (so security
+            researchers should then not trust it). Make sure you update this value periodcally and keep your file under review.
+        spec: 5
+        input: datetime
+    -
         name: Encryption
         id: encryption
         tags: ['Optional']
@@ -113,9 +122,9 @@ directives:
                     <ul class="list-of-inputs">
                         <li class="field">
                             <div class="control">
-                                <input class="input" placeholder="{{ directive.placeholder }}"
-                                       {% if directive.tags contains 'Required' %} required {% endif %}
-                                >
+                               <input data-display="inline" type="{{ directive.input }}" class="input" placeholder="{{ directive.placeholder }}"
+                                   {% if directive.tags contains 'Required' %} required {% endif %}
+                               >
                             </div>
                         </li>
                     </ul>

--- a/js/genform.js
+++ b/js/genform.js
@@ -1,13 +1,50 @@
+// Attach the Bulma calendar
+var YEAR = 60 * 60 * 24 * 366;
+var NOW = new Date();
+
+var calendar = bulmaCalendar.attach('[type="datetime"]', {
+    'minDate': NOW,
+    'maxDate': new Date(+NOW + YEAR)
+})[0];
+
 textareaElement = document.getElementById("text-to-copy");
 
 genform.addEventListener("submit", function(event){
     event.preventDefault();
+
+    // Handle 'Expires' as a special case - so don't include it here
     generate('security.txt', [
         "contact", "encryption", "acknowledgments", "preferredLanguages", "canonical", "policy", "hiring"
     ]);
 
     scrollToStepTwo()
 });
+
+function formatDate(date) {
+    var monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                      "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+    return zeroFill(date.getDate(), 2) + " " +
+           monthNames[date.getMonth()] + " " +
+           date.getFullYear() + " " +
+           timezoneOffset(date.getTimezoneOffset());
+}
+
+function zeroFill(num, length) {
+    num = num.toString();
+    while (num.length < length) {
+        num = "0" + num;
+    }
+    return num;
+}
+
+function timezoneOffset(mins) {
+    var hourOffset = Math.abs(Math.floor(mins / 60));
+    mins %= 60;
+
+    var sgn = mins >= 0 ? '+' : '-';
+    return sgn + zeroFill(hourOffset, 2) + zeroFill(mins, 2);
+}
 
 function generate(filename, field_array){
     var text = "";
@@ -27,12 +64,13 @@ function generate(filename, field_array){
         var inputs = document.getElementById(e).querySelector(".list-of-inputs")
 
         inputs.querySelectorAll("input").forEach(function(child) {
-            if(child.value.length > 0){
+            if (child.value.length > 0){
                 text += camelToHyphen(e) + ": " + child.value + "\n";
             }
         });
     });
 
+    text += "Expires: " + formatDate(calendar.date.start);
     textareaElement.value = text;
 
     if (document.queryCommandSupported("copy")) {


### PR DESCRIPTION
Closes #41 

Here is a picture of the new entry into the generation form. It doesn't look too different to the other inputs, which I think is quite nice:

![An inputbox with a calendar icon to the left, and an example date and time already inputted. The box is titled 'Expires' and has a short description which reads 'The date and time when the content of the security.txt file should be considered stale (so security researchers should then not trust it). Make sure you update this value periodcally and keep your file under review. See the full description of Expires'](https://user-images.githubusercontent.com/18113170/93647533-8a922900-fa00-11ea-9c3f-f199daa14517.png)

In theory, this PR could be merged now and the functionality is all there. But first I want to go through and fix stuff up:
- [X] ~~consider using `Intl` JS API for formatting dates~~
- [ ] decide how to handle timezones
- [ ] remove the 'Validate' button in the calendar which causes the form to prematurely submit
- [ ] investigate accessibility (especially keyboard accessibility) with the calendar. This Bulma extension is incredibly useful but e.g. tabbing into it seems to not be obvious
- [ ] code cleanup: make 'Expires' less of a special case
- [x] in the `defaults.html`, add a comment just for the Bulma extension bit
- [ ] consider using the JS file with all the bulma extensions, since a future PR will be using the form validation one too
- [X] there's a typo in the description for 'Expires' (periodically is misspelled)