### PR TITLE
Add 'Expires' to security.txt genform

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,13 +76,9 @@ directives:
         help: A link to any security-related job openings in your organisation. Remember to include "https://".
         placeholder: https://example.com/jobs.html
         spec: 6
-genform_version: -08
+genform_version: -10
 latest_draft_version: -10
-draft_genform_delta: >
-            It's missing the <code>Expires:</code> field, so you will have to manually insert it into the generated
-            file yourself. You can learn more about it from
-            <a target="_blank" rel="noopener noreferrer" 
-               href="https://tools.ietf.org/html/draft-foudil-securitytxt-10#section-3.5.5">the specification</a>.
+draft_genform_delta: nil 
 ---
 
 <div id="txt-notification">

--- a/index.html
+++ b/index.html
@@ -17,6 +17,15 @@ directives:
         placeholder: mailto:security@example.com
         spec: 3
     -
+        name: Expires
+        id: expires
+        tags: ['Required', 'Only 1 allowed']
+        help: >
+            The date and time when the content of the security.txt file should be considered stale (so security
+            researchers should then not trust it). Make sure you update this value periodically and keep your
+            file under review.
+        input: datetime
+    -
         name: Encryption
         id: encryption
         tags: ['Optional']
@@ -111,13 +120,24 @@ directives:
                         </a>
                     </p>
                     <ul class="list-of-inputs">
-                        <li class="field">
-                            <div class="control">
-                                <input class="input" placeholder="{{ directive.placeholder }}"
-                                       {% if directive.tags contains 'Required' %} required {% endif %}
-                                >
-                            </div>
-                        </li>
+                        {% if directive.input == 'datetime' %}
+                            <li class="field has-addons">
+                                <div class="control">
+                                    <input type="date" placeholder="YYYY-MM-DD" class="input" required>
+                                </div>
+                                <div class="control">
+                                    <input type="time" placeholder="HH:MM" class="input" required>
+                                </div>
+                            </li>
+                        {% else %}
+                            <li class="field">
+                                <div class="control">
+                                    <input class="input" placeholder="{{ directive.placeholder }}" type="{{ directive.input }}"
+                                           {% if directive.tags contains 'Required' %} required {% endif %}
+                                    >
+                                </div>
+                            </li>
+                        {% endif %}
                     </ul>
                     <div class="field">
                         <div class="control">

--- a/index.html
+++ b/index.html
@@ -76,6 +76,13 @@ directives:
         help: A link to any security-related job openings in your organisation. Remember to include "https://".
         placeholder: https://example.com/jobs.html
         spec: 6
+genform_version: -08
+latest_draft_version: -10
+draft_genform_delta: >
+            It's missing the <code>Expires:</code> field, so you will have to manually insert it into the generated
+            file yourself. You can learn more about it from
+            <a target="_blank" rel="noopener noreferrer" 
+               href="https://tools.ietf.org/html/draft-foudil-securitytxt-10#section-3.5.5">the specification</a>.
 ---
 
 <div id="txt-notification">
@@ -104,17 +111,26 @@ directives:
         <p>Create a text file called <code>security.txt</code> under the <code>.well-known</code> directory of your project.</p>
         <br>
         <form id="genform">
-            <article class="message is-warning">
+            {% if page.latest_draft_version == page.genform_version %}
+                {% assign is_up_to_date = true %}
+            {% else %}
+                {% assign is_up_to_date = false %}
+            {% endif%}
+            <article class="message {% if is_up_to_date %} is-success {% else %} is-warning {% endif %}">
                 <div class="message-header">
-                    <p>Form is out-of-date</p>
+                    <p>{% if is_up_to_date %} Form is up-to-date {% else %} Form is out-of-date {% endif %}</p>
                 </div>
                 <div class="message-body">
                     <p>
-                        This form is for version <strong>-08</strong>, but the latest published draft is <strong>-10</strong>.
-                        It's missing the <code>Expires:</code> field, so you will have to manually insert it into the generated file yourself.
-                        You can learn more about it from
-                        <a target="_blank" rel="noopener"
-                           href="https://tools.ietf.org/html/draft-foudil-securitytxt-10#section-3.5.5">the specification</a>.
+                        {% if is_up_to_date %}
+                            This form is up-to-date with the latest Internet draft at the time of writing. The Internet draft is subject
+                            to change, so you may want to verify that version <strong>{{ page.latest_draft_version }}</strong> is still the
+                            <a target="_blank" rel="noopener" href="https://tools.ietf.org/html/draft-foudil-securitytxt">latest
+                            version</a> &mdash; and if not, to check for any differences.
+                        {% else %}
+                            This form is for version <strong>{{ page.genform_version }}</strong>, but the latest published draft is
+                            <strong>{{ page.latest_draft_version }}</strong>. {{ page.draft_genform_delta }}
+                        {% endif %}
                     </p>
                 </div>
             </article>

--- a/index.html
+++ b/index.html
@@ -56,8 +56,8 @@ directives:
         tags: ['Optional']
         help: >
             The URLs for accessing your security.txt file. It is important to include this if you are
-            digitally signing the security.txt file, so that researchers can know for sure that you didn't just steal
-            someone else's file with the same content.
+            digitally signing the security.txt file, so that the location of the security.txt file can be digitally
+            signed too.
         placeholder: https://example.com/.well-known/security.txt
         spec: 2
     -

--- a/js/genform.js
+++ b/js/genform.js
@@ -3,11 +3,49 @@ textareaElement = document.getElementById("text-to-copy");
 genform.addEventListener("submit", function(event){
     event.preventDefault();
     generate('security.txt', [
-        "contact", "encryption", "acknowledgments", "preferredLanguages", "canonical", "policy", "hiring"
+        "contact", "expires", "encryption", "acknowledgments", "preferredLanguages", "canonical", "policy", "hiring"
     ]);
 
     scrollToStepTwo()
 });
+
+// Convert a date string and time string into a string compliant with the RFC
+// Date string: YYYY-MM-DD, Time string: HH:MM (just like browsers will return for date/time inputs)
+function formatDate(dateString, timeString) {
+    var monthNames = [
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+    ];
+
+    var splitDate = dateString.split("-");
+
+    return [
+        splitDate[0],
+        monthNames[splitDate[1] - 1],
+        splitDate[2],
+        timeString,
+        getTimezone((new Date).getTimezoneOffset())
+    ].join(" ");
+
+    function pad(num) {
+        return num.toString().padStart(2, '0');
+    }
+
+    function getTimezone(offset) {
+        // Converts e.g. -90 to "-0130" i.e. "+/- HHMM"
+        
+        // Sign +/-
+        var timezone = offset < 0 ? "-" : "+";
+        offset = Math.abs(offset);
+
+        // HH (pad with '0' to ensure length is 2)
+        timezone += pad(Math.floor(offset / 60));
+        offset %= 60;
+
+        // MM (pad with '0' to ensure length is 2)
+        timezone += pad(offset);
+        return timezone;
+    }
+}
 
 function generate(filename, field_array){
     var text = "";
@@ -24,13 +62,20 @@ function generate(filename, field_array){
 
     field_array.forEach(function(e){
         console.log(e)
-        var inputs = document.getElementById(e).querySelector(".list-of-inputs")
 
-        inputs.querySelectorAll("input").forEach(function(child) {
-            if(child.value.length > 0){
-                text += camelToHyphen(e) + ": " + child.value + "\n";
-            }
-        });
+        if (e == "expires") {
+            var dateInput = document.getElementById(e).querySelector("[type='date']");
+            var timeInput = document.getElementById(e).querySelector("[type='time']");
+
+            text += camelToHyphen(e) + ": " + formatDate(dateInput.value, timeInput.value);
+        } else {
+            var inputs = document.getElementById(e).querySelector(".list-of-inputs")
+            inputs.querySelectorAll("input").forEach(function(child) {
+                if(child.value.length > 0){
+                    text += camelToHyphen(e) + ": " + child.value + "\n";
+                }
+            });
+        }
     });
 
     textareaElement.value = text;

--- a/js/genform.js
+++ b/js/genform.js
@@ -12,19 +12,14 @@ genform.addEventListener("submit", function(event){
 // Convert a date string and time string into a string compliant with the RFC
 // Date string: YYYY-MM-DD, Time string: HH:MM (just like browsers will return for date/time inputs)
 function formatDate(dateString, timeString) {
-    var monthNames = [
-        "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
-    ];
+    var date = new Date(dateString + ' ' + timeString);
 
-    var splitDate = dateString.split("-");
+    var monthName = new Intl.DateTimeFormat('en-US', { 'month': 'short' }).format(date);
+    var weekdayName = new Intl.DateTimeFormat('en-US', { 'weekday': 'short' }).format(date);
 
-    return [
-        Number(splitDate[2]).toString(),
-        monthNames[splitDate[1] - 1],
-        splitDate[0],
-        timeString,
-        getTimezone(-(new Date).getTimezoneOffset())
-    ].join(" ");
+    return weekdayName + ', ' + // (e.g. "Thu,")
+        date.getDate() + ' ' + monthName + ' ' + date.getFullYear() + ' ' + // (e.g. "2 Jan 1971")
+        timeString + ' ' + getTimezone(-(new Date).getTimezoneOffset()); // (e.g. "12:00 +0100")
 
     function pad(num) {
         return num.toString().padStart(2, '0');

--- a/js/genform.js
+++ b/js/genform.js
@@ -23,7 +23,7 @@ function formatDate(dateString, timeString) {
         monthNames[splitDate[1] - 1],
         splitDate[2],
         timeString,
-        getTimezone((new Date).getTimezoneOffset())
+        getTimezone(-(new Date).getTimezoneOffset())
     ].join(" ");
 
     function pad(num) {

--- a/js/genform.js
+++ b/js/genform.js
@@ -19,9 +19,9 @@ function formatDate(dateString, timeString) {
     var splitDate = dateString.split("-");
 
     return [
-        splitDate[0],
+        Number(splitDate[2]).toString(),
         monthNames[splitDate[1] - 1],
-        splitDate[2],
+        splitDate[0],
         timeString,
         getTimezone(-(new Date).getTimezoneOffset())
     ].join(" ");


### PR DESCRIPTION
Resolves #41 

Here is what it would look like if you're using a browser which doesn't support `date` or `time` inputs. An example of such a browser is Safari for `time`, or Internet Explorer for both (although in this PR I've decided to write JS which does not support IE):

![Two text inputs next to each other, with the greyed out placeholder stating the format for the first is YYYY-MM-DD and the format for the second is HH:MM](https://user-images.githubusercontent.com/18113170/93672192-e1e7d600-faa0-11ea-8aaf-3426cc26856e.png)

This is what it looks like for most modern browsers (the date format will be locale-sensitive):

![A date input in the form dd/mm/yyyy and the time input in the form --:--](https://user-images.githubusercontent.com/18113170/93672219-03e15880-faa1-11ea-9a0c-98b4d93ac7d0.png)

Where clicking on the appropriate icons will bring up the browser's calendar or time UI.

The two inputs are set to 'required' but there's currently no validation otherwise. If you're using a modern browser, there's not really a way of inputting an invalid date; but if you're using the text versions then you could mess it up completely. We'll add validation for all the fields in another PR soon.

This PR should be good to merge 👍 