### PR TITLE
Add newline on end of Expires field

### DIFF
--- a/js/genform.js
+++ b/js/genform.js
@@ -62,7 +62,7 @@ function generate(filename, field_array){
             var dateInput = document.getElementById(e).querySelector("[type='date']");
             var timeInput = document.getElementById(e).querySelector("[type='time']");
 
-            text += camelToHyphen(e) + ": " + formatDate(dateInput.value, timeInput.value);
+            text += camelToHyphen(e) + ": " + formatDate(dateInput.value, timeInput.value) + "\n";
         } else {
             var inputs = document.getElementById(e).querySelector(".list-of-inputs")
             inputs.querySelectorAll("input").forEach(function(child) {


### PR DESCRIPTION
Resolves #69. 

Before the fix is applied: 

![image](https://user-images.githubusercontent.com/6162814/111080794-11b2ec00-84ce-11eb-986f-91e351f8a7cc.png)

After the fix is applied: 

![image](https://user-images.githubusercontent.com/6162814/111080802-1ecfdb00-84ce-11eb-9987-2161f82308be.png)

Simply adds a newline to the generation javascript same as other fields currently do. 

Please let me know if you need anything else for this to be merged/considered. 