### PR TITLE
Add Expires & fix spelling in security.txt file

### DIFF
--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -2,4 +2,5 @@
 # you may report it to us on HackerOne.
 Contact: https://hackerone.com/ed
 Encryption: https://keybase.pub/edoverflow/pgp_key.asc
-Acknowledgements: https://hackerone.com/ed/thanks
+Acknowledgments: https://hackerone.com/ed/thanks
+Expires: Mon, 14 Mar 2022 00:00 +0000


### PR DESCRIPTION
Some quick fixes to make our file spec-compliant.
- The specification uses the American spelling of Acknowledgments (rather than Acknowledg***E***ments)
- Add an Expires field for one year into the future