### PR TITLE
Add Safari compatibility

### DIFF
--- a/js/genform.js
+++ b/js/genform.js
@@ -12,7 +12,9 @@ genform.addEventListener("submit", function(event){
 // Convert a date string and time string into a string compliant with the RFC
 // Date string: YYYY-MM-DD, Time string: HH:MM (just like browsers will return for date/time inputs)
 function formatDate(dateString, timeString) {
-    var date = new Date(dateString + ' ' + timeString);
+    // The replace operation is for Safari compatibility: it can only parse YYYY/MM/DD dates and most
+    // other browsers support both YYYY-MM-DD and YYYY/MM/DD.
+    var date = new Date(dateString.replace(/-/g, '/') + ' ' + timeString);
 
     var monthName = new Intl.DateTimeFormat('en-US', { 'month': 'short' }).format(date);
     var weekdayName = new Intl.DateTimeFormat('en-US', { 'weekday': 'short' }).format(date);


### PR DESCRIPTION
If a browser supports an HTML `date` input type, then the selected date will be presented to JS in the form `YYYY-MM-DD`. Safari does not have this UI, so instead the user is prompted to enter the date in that exact same format.

However, `YYYY-MM-DD` is not a format that the JavaScript `Date` constructor recognises in Safari (see [Invalid Date in Safari](https://stackoverflow.com/questions/4310953/invalid-date-in-safari) on StackOverflow).

Before passing the date (whether it came from the user or the UI) to the `Date` constructor, this PR replaces all `-` symbols with `/` symbols. This is a format that Safari apparently recognises.

I have tested on Chrome to make sure it continues to work - I expect most modern browsers should support `YYYY/MM/DD` format.

Future work is to add validation to make sure that user inputs -- especially date inputs on Safari -- are actually valid dates. Part of that will be better error handling that will let the user know something went wrong. This is just a quick fix for Safari users but also any other browsers that don't support YYYY-MM-DD dates even if they do support the date picker UI.