### PR TITLE
Add validation to Contact field

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,6 +130,17 @@ draft_genform_delta: nil
                     </p>
                 </div>
             </article>
+			
+			<article id="validation-errors-box" class="message is-danger is-hidden">
+				<div class="message-body">
+					<p>
+						The Contact field failed to validate. Please ensure it starts with <code>mailto:</code> for e-mail addresses,
+						<code>tel:</code> for telephone numbers, or <code>https://</code> for web URIs.
+					</p>
+					<p>For example, <code>mailto:contact@example.com</code>.</p>
+				</div>
+			</article>
+
             {% for directive in page.directives %}
                 <fieldset class="box" id="{{directive.id}}">
                     <legend class="label">
@@ -160,7 +171,13 @@ draft_genform_delta: nil
                                 <div class="control">
                                     <input class="input" placeholder="{{ directive.placeholder }}" type="{{ directive.input }}"
                                            {% if directive.tags contains 'Required' %} required {% endif %}
+                                           {% if directive.id == 'contact' %} oninput='checkContactValidity(this);' {% endif %}
                                     >
+									{% if directive.id == 'contact' %}
+										<p class="is-hidden help is-danger">
+											Each contact field must begin with https:// for web URIs; tel: for telephone numbers; or mailto: for e-mails.
+										</p>
+									{% endif %}
                                 </div>
                             </li>
                         {% endif %}

--- a/index.html
+++ b/index.html
@@ -130,16 +130,16 @@ draft_genform_delta: nil
                     </p>
                 </div>
             </article>
-			
-			<article id="validation-errors-box" class="message is-danger is-hidden">
-				<div class="message-body">
-					<p>
-						The Contact field failed to validate. Please ensure it starts with <code>mailto:</code> for e-mail addresses,
-						<code>tel:</code> for telephone numbers, or <code>https://</code> for web URIs.
-					</p>
-					<p>For example, <code>mailto:contact@example.com</code>.</p>
-				</div>
-			</article>
+
+            <article id="validation-errors-box" class="message is-danger is-hidden">
+                <div class="message-body">
+                    <p>
+                        The Contact field failed to validate. Please ensure it starts with <code>mailto:</code> for e-mail addresses,
+                        <code>tel:</code> for telephone numbers, or <code>https://</code> for web URIs.
+                    </p>
+                    <p>For example, <code>mailto:contact@example.com</code>.</p>
+                </div>
+            </article>
 
             {% for directive in page.directives %}
                 <fieldset class="box" id="{{directive.id}}">
@@ -173,11 +173,11 @@ draft_genform_delta: nil
                                            {% if directive.tags contains 'Required' %} required {% endif %}
                                            {% if directive.id == 'contact' %} oninput='checkContactValidity(this);' {% endif %}
                                     >
-									{% if directive.id == 'contact' %}
-										<p class="is-hidden help is-danger">
-											Each contact field must begin with https:// for web URIs; tel: for telephone numbers; or mailto: for e-mails.
-										</p>
-									{% endif %}
+                                    {% if directive.id == 'contact' %}
+                                        <p class="is-hidden help is-danger">
+                                            Each contact field must begin with https:// for web URIs; tel: for telephone numbers; or mailto: for e-mails.
+                                        </p>
+                                    {% endif %}
                                 </div>
                             </li>
                         {% endif %}
@@ -224,8 +224,8 @@ draft_genform_delta: nil
         <p>security.txt is currently an Internet draft that has been submitted for <abbr title="Request For Comments">RFC</abbr> review. This means that security.txt is still in the early stages of development. We welcome contributions from the public: <a href="https://github.com/securitytxt/security-txt">https://github.com/securitytxt/security-txt</a></p>
         <h5>Where should I put the security.txt file?</h5>
         <p>For websites, the security.txt file should be placed under the <code>/.well-known/</code> path (<code>/.well-known/security.txt</code>) [<a href="https://tools.ietf.org/html/rfc8615"><abbr title="Request For Comments">RFC</abbr>8615</a>]. It can also be placed in the root directory (<code>/security.txt</code>) of a website, especially if the <code>/.well-known/</code> directory cannot be used for technical reasons, or simply as a fallback. The file can be placed in both locations of a website at the same time.</p>
-				<h5>Are there any settings I should apply to the file?</h5>
-				<p>The security.txt file should have an Internet Media Type of <code>text/plain</code> and must be served over HTTPS.</p>
+                <h5>Are there any settings I should apply to the file?</h5>
+                <p>The security.txt file should have an Internet Media Type of <code>text/plain</code> and must be served over HTTPS.</p>
         <h5>Will adding an email address expose me to spam bots?</h5>
         <p>The email value is an optional field. If you are worried about spam, you can set a URI as the value and link to your security policy.</p>
     </div>

--- a/js/genform.js
+++ b/js/genform.js
@@ -6,7 +6,7 @@ genform.addEventListener("submit", function(event){
 	// First, validate the form
 	var didValidationFail = false;
 	var contactInputElements = document.getElementById('contact').getElementsByTagName('input');
-	
+
 	for (var i = 0; i < contactInputElements.length; i++) {
 		var inputEl = contactInputElements[i];
 		checkContactValidity(inputEl);
@@ -157,7 +157,7 @@ function copyTextarea(){
     textareaElement.select();
     document.execCommand("copy");
 
-    indow.getSelection().empty();
+    window.getSelection().empty();
     showNotification();
 }
 

--- a/js/genform.js
+++ b/js/genform.js
@@ -2,6 +2,28 @@ textareaElement = document.getElementById("text-to-copy");
 
 genform.addEventListener("submit", function(event){
     event.preventDefault();
+
+	// First, validate the form
+	var didValidationFail = false;
+	var contactInputElements = document.getElementById('contact').getElementsByTagName('input');
+	
+	for (var i = 0; i < contactInputElements.length; i++) {
+		var inputEl = contactInputElements[i];
+		checkContactValidity(inputEl);
+
+		if (!isContactValid(inputEl)) {
+			inputEl.focus();
+			didValidationFail = true;
+		}
+	}
+
+	if (didValidationFail) {
+		document.getElementById('validation-errors-box').classList.remove('is-hidden');
+		return;
+	} else {
+		document.getElementById('validation-errors-box').classList.add('is-hidden');
+	}
+
     generate('security.txt', [
         "contact", "expires", "encryption", "acknowledgments", "preferredLanguages", "canonical", "policy", "hiring"
     ]);
@@ -89,9 +111,23 @@ function addAlternative(button) {
     newInput.setAttribute("placeholder", "Another possible alternative")
     newInput.setAttribute("class", "input")
 
-    var newInputControl = document.createElement("DIV")
+	var newInputControl = document.createElement("DIV")
     newInputControl.setAttribute("class", "control is-expanded")
     newInputControl.appendChild(newInput)
+
+	if (button.parentElement.parentElement.parentElement.id === 'contact') {
+		newInput.addEventListener('input', function () { checkContactValidity(newInput); }) 
+		
+		var errorMessage = document.createElement('P');
+		newInputControl.appendChild(errorMessage);
+		errorMessage.textContent = 'Each contact field must begin with https:// for web URIs; tel: for telephone numbers; or mailto: for e-mails.';
+		
+		var ERROR_MESSAGE_CLASSES = ['is-danger', 'is-hidden', 'help']
+		
+		for (var i = 0; i < ERROR_MESSAGE_CLASSES.length; i++) {
+			errorMessage.classList.add(ERROR_MESSAGE_CLASSES[i])
+		}
+	}
 
     var removeButton = document.createElement("BUTTON")
     removeButton.setAttribute("type", "button")
@@ -121,7 +157,7 @@ function copyTextarea(){
     textareaElement.select();
     document.execCommand("copy");
 
-    window.getSelection().empty();
+    indow.getSelection().empty();
     showNotification();
 }
 
@@ -153,4 +189,20 @@ function showNotification(){
         // doesn't work when called on the same tick
         notification.classList.add("opaque");
     });
+}
+
+function isContactValid(el) {
+	var VALIDATION_REGEX = /^(mailto:|https:\/\/|tel:)/i;
+	
+	return VALIDATION_REGEX.test(el.value);
+}
+
+function checkContactValidity(el) {
+	if (isContactValid(el)) {
+		el.parentElement.getElementsByTagName("p")[0].classList.add('is-hidden');
+		el.classList.remove('is-danger');
+	} else {
+		el.parentElement.getElementsByTagName("p")[0].classList.remove('is-hidden')
+		el.classList.add('is-danger');
+	}
 }

--- a/js/genform.js
+++ b/js/genform.js
@@ -3,26 +3,26 @@ textareaElement = document.getElementById("text-to-copy");
 genform.addEventListener("submit", function(event){
     event.preventDefault();
 
-	// First, validate the form
-	var didValidationFail = false;
-	var contactInputElements = document.getElementById('contact').getElementsByTagName('input');
+    // First, validate the form
+    var didValidationFail = false;
+    var contactInputElements = document.getElementById('contact').getElementsByTagName('input');
 
-	for (var i = 0; i < contactInputElements.length; i++) {
-		var inputEl = contactInputElements[i];
-		checkContactValidity(inputEl);
+    for (var i = 0; i < contactInputElements.length; i++) {
+        var inputEl = contactInputElements[i];
+        checkContactValidity(inputEl);
 
-		if (!isContactValid(inputEl)) {
-			inputEl.focus();
-			didValidationFail = true;
-		}
-	}
+        if (!isContactValid(inputEl)) {
+            inputEl.focus();
+            didValidationFail = true;
+        }
+    }
 
-	if (didValidationFail) {
-		document.getElementById('validation-errors-box').classList.remove('is-hidden');
-		return;
-	} else {
-		document.getElementById('validation-errors-box').classList.add('is-hidden');
-	}
+    if (didValidationFail) {
+        document.getElementById('validation-errors-box').classList.remove('is-hidden');
+        return;
+    } else {
+        document.getElementById('validation-errors-box').classList.add('is-hidden');
+    }
 
     generate('security.txt', [
         "contact", "expires", "encryption", "acknowledgments", "preferredLanguages", "canonical", "policy", "hiring"
@@ -51,7 +51,7 @@ function formatDate(dateString, timeString) {
 
     function getTimezone(offset) {
         // Converts e.g. -90 to "-0130" i.e. "+/- HHMM"
-        
+
         // Sign +/-
         var timezone = offset < 0 ? "-" : "+";
         offset = Math.abs(offset);
@@ -68,7 +68,7 @@ function formatDate(dateString, timeString) {
 
 function generate(filename, field_array){
     var text = "";
-    
+
     // Converts camel case like 'abcDefGhi' into
     // the format 'Abc-Def-Ghi'
     function camelToHyphen(camelCaseWord) {
@@ -106,28 +106,28 @@ function generate(filename, field_array){
 
 function addAlternative(button) {
     var list = button.parentElement.parentElement.parentElement.querySelector(".list-of-inputs")
-    
+
     var newInput = document.createElement("INPUT")
     newInput.setAttribute("placeholder", "Another possible alternative")
     newInput.setAttribute("class", "input")
 
-	var newInputControl = document.createElement("DIV")
+    var newInputControl = document.createElement("DIV")
     newInputControl.setAttribute("class", "control is-expanded")
     newInputControl.appendChild(newInput)
 
-	if (button.parentElement.parentElement.parentElement.id === 'contact') {
-		newInput.addEventListener('input', function () { checkContactValidity(newInput); }) 
-		
-		var errorMessage = document.createElement('P');
-		newInputControl.appendChild(errorMessage);
-		errorMessage.textContent = 'Each contact field must begin with https:// for web URIs; tel: for telephone numbers; or mailto: for e-mails.';
-		
-		var ERROR_MESSAGE_CLASSES = ['is-danger', 'is-hidden', 'help']
-		
-		for (var i = 0; i < ERROR_MESSAGE_CLASSES.length; i++) {
-			errorMessage.classList.add(ERROR_MESSAGE_CLASSES[i])
-		}
-	}
+    if (button.parentElement.parentElement.parentElement.id === 'contact') {
+        newInput.addEventListener('input', function () { checkContactValidity(newInput); }); 
+
+        var errorMessage = document.createElement('P');
+        newInputControl.appendChild(errorMessage);
+        errorMessage.textContent = 'Each contact field must begin with https:// for web URIs; tel: for telephone numbers; or mailto: for e-mails.';
+
+        var ERROR_MESSAGE_CLASSES = ['is-danger', 'is-hidden', 'help']
+
+        for (var i = 0; i < ERROR_MESSAGE_CLASSES.length; i++) {
+            errorMessage.classList.add(ERROR_MESSAGE_CLASSES[i])
+        }
+    }
 
     var removeButton = document.createElement("BUTTON")
     removeButton.setAttribute("type", "button")
@@ -192,17 +192,17 @@ function showNotification(){
 }
 
 function isContactValid(el) {
-	var VALIDATION_REGEX = /^(mailto:|https:\/\/|tel:)/i;
-	
-	return VALIDATION_REGEX.test(el.value);
+    var VALIDATION_REGEX = /^(mailto:|https:\/\/|tel:)/i;
+
+    return VALIDATION_REGEX.test(el.value);
 }
 
 function checkContactValidity(el) {
-	if (isContactValid(el)) {
-		el.parentElement.getElementsByTagName("p")[0].classList.add('is-hidden');
-		el.classList.remove('is-danger');
-	} else {
-		el.parentElement.getElementsByTagName("p")[0].classList.remove('is-hidden')
-		el.classList.add('is-danger');
-	}
+    if (isContactValid(el)) {
+        el.parentElement.getElementsByTagName("p")[0].classList.add('is-hidden');
+        el.classList.remove('is-danger');
+    } else {
+        el.parentElement.getElementsByTagName("p")[0].classList.remove('is-hidden')
+        el.classList.add('is-danger');
+    }
 }


### PR DESCRIPTION
This is a quick fix, and it may be a good idea to follow up with a more long-term solution to validation.

![The input box gets a red border and a piece of text underneath describes the validation issue](https://user-images.githubusercontent.com/18113170/124998281-06b73500-e044-11eb-8460-624360f69db4.png)

The above message appears as the user is typing. If the user chooses to submit despite the warning, the input box regains focus (thus scrolling them so that the input box is on screen), the security.txt file is not generated, and an additional red box appears at the top.

![The red box is larger and gives an example of how to format an email address](https://user-images.githubusercontent.com/18113170/124998408-48e07680-e044-11eb-8200-bf108ecc0343.png)

The red box does not disappear until the user submits the form again, even after they have corrected all the issues.

**Note**: the validation only checks that the input begins with `https://`, `mailto:` or `tel:`. It does not validate the content afterwards (such as whether there is an `@` if `mailto:` is used) but this can potentially be added in a follow-up PR.