### PR TITLE
Auto-add mailto: prefix onchange

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,8 +171,11 @@ draft_genform_delta: nil
                             <li class="field">
                                 <div class="control">
                                     <input class="input" placeholder="{{ directive.placeholder }}" type="{{ directive.input }}"
-                                           {% if directive.tags contains 'Required' %} required {% endif %}
-                                           {% if directive.id == 'contact' %} oninput='checkContactValidity(this);' {% endif %}
+                                        {% if directive.tags contains 'Required' %} required {% endif %}
+                                        {% if directive.id == 'contact' %}
+                                            oninput='checkContactValidity(this);'
+                                            onchange='autoprefixEmail(this);'
+                                        {% endif %}
                                     >
                                     {% if directive.id == 'contact' %}
                                         <p class="is-hidden help is-danger">

--- a/index.html
+++ b/index.html
@@ -173,7 +173,6 @@ draft_genform_delta: nil
                                     <input class="input" placeholder="{{ directive.placeholder }}" type="{{ directive.input }}"
                                         {% if directive.tags contains 'Required' %} required {% endif %}
                                         {% if directive.id == 'contact' %}
-                                            oninput='checkContactValidity(this);'
                                             onchange='autoprefixEmail(this);'
                                         {% endif %}
                                     >

--- a/js/genform.js
+++ b/js/genform.js
@@ -90,7 +90,6 @@ function addAlternative(button) {
     newInputControl.appendChild(newInput)
 
     if (button.parentElement.parentElement.parentElement.id === 'contact') {
-        newInput.addEventListener('input', function () { checkContactValidity(newInput); }); 
         newInput.addEventListener('change', function () { autoprefixEmail(newInput); });
 
         var errorMessage = document.createElement('P');

--- a/js/genform.js
+++ b/js/genform.js
@@ -188,7 +188,7 @@ function autoprefixEmail(el) {
     // NOTE: If this regular expression is changed in future, it should always fail if
     // the user enters some other schema (e.g. https://) so they always have the option of overriding it.
     // Currently this is achieved by not allowing a colon to appear in the input.
-    if (/^[a-z_+.-]+@[a-z_+.-]+$/i.test(el.value)) {
+    if (/^[a-z0-9_+.-]+@[a-z0-9_+.-]+$/i.test(el.value)) {
         el.value = 'mailto:' + el.value;
     }
 

--- a/js/genform.js
+++ b/js/genform.js
@@ -91,6 +91,7 @@ function addAlternative(button) {
 
     if (button.parentElement.parentElement.parentElement.id === 'contact') {
         newInput.addEventListener('input', function () { checkContactValidity(newInput); }); 
+        newInput.addEventListener('change', function () { autoprefixEmail(newInput); });
 
         var errorMessage = document.createElement('P');
         newInputControl.appendChild(errorMessage);
@@ -179,4 +180,17 @@ function checkContactValidity(el) {
         el.parentElement.getElementsByTagName("p")[0].classList.remove('is-hidden')
         el.classList.add('is-danger');
     }
+}
+
+function autoprefixEmail(el) {
+    // Add mailto: prefix, e.g. contact@example.com -> mailto:contact@example.com
+
+    // NOTE: If this regular expression is changed in future, it should always fail if
+    // the user enters some other schema (e.g. https://) so they always have the option of overriding it.
+    // Currently this is achieved by not allowing a colon to appear in the input.
+    if (/^[a-z_+.-]+@[a-z_+.-]+$/i.test(el.value)) {
+        el.value = 'mailto:' + el.value;
+    }
+
+    checkContactValidity(el); // potentially remove validation error if issue resolved
 }

--- a/js/genform.js
+++ b/js/genform.js
@@ -181,15 +181,15 @@ function checkContactValidity(el) {
     }
 }
 
-function autoprefixEmail(el) {
+function autoprefixEmail(inputEl) {
     // Add mailto: prefix, e.g. contact@example.com -> mailto:contact@example.com
 
     // NOTE: If this regular expression is changed in future, it should always fail if
     // the user enters some other schema (e.g. https://) so they always have the option of overriding it.
     // Currently this is achieved by not allowing a colon to appear in the input.
-    if (/^[a-z0-9_+.-]+@[a-z0-9_+.-]+$/i.test(el.value)) {
-        el.value = 'mailto:' + el.value;
+    if (/^[a-z0-9_+.-]+@[a-z0-9_+.-]+$/i.test(inputEl.value)) {
+        inputEl.value = 'mailto:' + inputEl.value;
     }
 
-    checkContactValidity(el); // potentially remove validation error if issue resolved
+    checkContactValidity(inputEl); // potentially remove validation error if issue resolved
 }


### PR DESCRIPTION
Resolves https://github.com/securitytxt/securitytxt.org/pull/81#issuecomment-877272606

Blurring the input in any way will check if the Contact input is in the form `user@domain`, where each of `user` and `domain` have length at least 1 and contain only alphanumeric characters
- A-Z
- 0-9
- `_`
- `+`
- `.`
- `-`

If it matches, then the prefix `mailto:` is added.

I'm not sure how useful this change will be because the validation error is shown as the user is typing, so they may try to fix it themselves instead of blurring the input. @nightwatchcyber / @rugk do you think it would be better to check after each key press (or more precisely, 'oninput')?